### PR TITLE
Replace deprecated methods

### DIFF
--- a/browser-version/out/nedb.js
+++ b/browser-version/out/nedb.js
@@ -1334,7 +1334,7 @@ Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callba
     // For a basic match
     usableQueryKeys = [];
     Object.keys(query).forEach(function (k) {
-      if (typeof query[k] === 'string' || typeof query[k] === 'number' || typeof query[k] === 'boolean' || util.isDate(query[k]) || query[k] === null) {
+      if (typeof query[k] === 'string' || typeof query[k] === 'number' || typeof query[k] === 'boolean' || util.types.isDate(query[k]) || query[k] === null) {
         usableQueryKeys.push(k);
       }
     });
@@ -1379,7 +1379,7 @@ Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callba
     docs.forEach(function (doc) {
       var valid = true;
       ttlIndexesFieldNames.forEach(function (i) {
-        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
+        if (doc[i] !== undefined && util.types.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
           valid = false;
         }
       });
@@ -1416,7 +1416,7 @@ Datastore.prototype._insert = function (newDoc, cb) {
     return callback(e);
   }
 
-  this.persistence.persistNewState(util.isArray(preparedDoc) ? preparedDoc : [preparedDoc], function (err) {
+  this.persistence.persistNewState(Array.isArray(preparedDoc) ? preparedDoc : [preparedDoc], function (err) {
     if (err) { return callback(err); }
     return callback(null, model.deepCopy(preparedDoc));
   });
@@ -1442,7 +1442,7 @@ Datastore.prototype.createNewId = function () {
 Datastore.prototype.prepareDocumentForInsertion = function (newDoc) {
   var preparedDoc, self = this;
 
-  if (util.isArray(newDoc)) {
+  if (Array.isArray(newDoc)) {
     preparedDoc = [];
     newDoc.forEach(function (doc) { preparedDoc.push(self.prepareDocumentForInsertion(doc)); });
   } else {
@@ -1462,7 +1462,7 @@ Datastore.prototype.prepareDocumentForInsertion = function (newDoc) {
  * @api private
  */
 Datastore.prototype._insertInCache = function (preparedDoc) {
-  if (util.isArray(preparedDoc)) {
+  if (Array.isArray(preparedDoc)) {
     this._insertMultipleDocsInCache(preparedDoc);
   } else {
     this.addToIndexes(preparedDoc);
@@ -1871,7 +1871,7 @@ function projectForUnique (elt) {
   if (typeof elt === 'string') { return '$string' + elt; }
   if (typeof elt === 'boolean') { return '$boolean' + elt; }
   if (typeof elt === 'number') { return '$number' + elt; }
-  if (util.isArray(elt)) { return '$date' + elt.getTime(); }
+  if (Array.isArray(elt)) { return '$date' + elt.getTime(); }
 
   return elt;   // Arrays and objects, will check for pointer equality
 }
@@ -1918,14 +1918,14 @@ Index.prototype.insert = function (doc) {
     , keys, i, failingI, error
     ;
 
-  if (util.isArray(doc)) { this.insertMultipleDocs(doc); return; }
+  if (Array.isArray(doc)) { this.insertMultipleDocs(doc); return; }
 
   key = model.getDotValue(doc, this.fieldName);
 
   // We don't index documents that don't contain the field if the index is sparse
   if (key === undefined && this.sparse) { return; }
 
-  if (!util.isArray(key)) {
+  if (!Array.isArray(key)) {
     this.tree.insert(key, doc);
   } else {
     // If an insert fails due to a unique constraint, roll back all inserts before it
@@ -1990,13 +1990,13 @@ Index.prototype.insertMultipleDocs = function (docs) {
 Index.prototype.remove = function (doc) {
   var key, self = this;
 
-  if (util.isArray(doc)) { doc.forEach(function (d) { self.remove(d); }); return; }
+  if (Array.isArray(doc)) { doc.forEach(function (d) { self.remove(d); }); return; }
 
   key = model.getDotValue(doc, this.fieldName);
 
   if (key === undefined && this.sparse) { return; }
 
-  if (!util.isArray(key)) {
+  if (!Array.isArray(key)) {
     this.tree.delete(key, doc);
   } else {
     _.uniq(key, projectForUnique).forEach(function (_key) {
@@ -2012,7 +2012,7 @@ Index.prototype.remove = function (doc) {
  * Naive implementation, still in O(log(n))
  */
 Index.prototype.update = function (oldDoc, newDoc) {
-  if (util.isArray(oldDoc)) { this.updateMultipleDocs(oldDoc); return; }
+  if (Array.isArray(oldDoc)) { this.updateMultipleDocs(oldDoc); return; }
 
   this.remove(oldDoc);
 
@@ -2071,7 +2071,7 @@ Index.prototype.updateMultipleDocs = function (pairs) {
 Index.prototype.revertUpdate = function (oldDoc, newDoc) {
   var revert = [];
 
-  if (!util.isArray(oldDoc)) {
+  if (!Array.isArray(oldDoc)) {
     this.update(newDoc, oldDoc);
   } else {
     oldDoc.forEach(function (pair) {
@@ -2090,7 +2090,7 @@ Index.prototype.revertUpdate = function (oldDoc, newDoc) {
 Index.prototype.getMatching = function (value) {
   var self = this;
 
-  if (!util.isArray(value)) {
+  if (!Array.isArray(value)) {
     return self.tree.search(value);
   } else {
     var _res = {}, res = [];
@@ -2191,7 +2191,7 @@ function checkKey (k, v) {
  * Works by applying the above checkKey function to all fields recursively
  */
 function checkObject (obj) {
-  if (util.isArray(obj)) {
+  if (Array.isArray(obj)) {
     obj.forEach(function (o) {
       checkObject(o);
     });
@@ -2261,11 +2261,11 @@ function deepCopy (obj, strictKeys) {
        typeof obj === 'number' ||
        typeof obj === 'string' ||
        obj === null ||
-       (util.isDate(obj)) ) {
+       (util.types.isDate(obj)) ) {
     return obj;
   }
 
-  if (util.isArray(obj)) {
+  if (Array.isArray(obj)) {
     res = [];
     obj.forEach(function (o) { res.push(deepCopy(o, strictKeys)); });
     return res;
@@ -2294,8 +2294,8 @@ function isPrimitiveType (obj) {
        typeof obj === 'number' ||
        typeof obj === 'string' ||
        obj === null ||
-       util.isDate(obj) ||
-       util.isArray(obj));
+       util.types.isDate(obj) ||
+       Array.isArray(obj));
 }
 
 
@@ -2359,12 +2359,12 @@ function compareThings (a, b, _compareStrings) {
   if (typeof b === 'boolean') { return typeof a === 'boolean' ? compareNSB(a, b) : 1; }
 
   // Dates
-  if (util.isDate(a)) { return util.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1; }
-  if (util.isDate(b)) { return util.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1; }
+  if (util.types.isDate(a)) { return util.types.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1; }
+  if (util.types.isDate(b)) { return util.types.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1; }
 
   // Arrays (first element is most significant and so on)
-  if (util.isArray(a)) { return util.isArray(b) ? compareArrays(a, b) : -1; }
-  if (util.isArray(b)) { return util.isArray(a) ? compareArrays(a, b) : 1; }
+  if (Array.isArray(a)) { return Array.isArray(b) ? compareArrays(a, b) : -1; }
+  if (Array.isArray(b)) { return Array.isArray(a) ? compareArrays(a, b) : 1; }
 
   // Objects
   aKeys = Object.keys(a).sort();
@@ -2420,7 +2420,7 @@ lastStepModifierFunctions.$push = function (obj, field, value) {
   // Create the array if it doesn't exist
   if (!obj.hasOwnProperty(field)) { obj[field] = []; }
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $push an element on non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $push an element on non-array values"); }
 
   if (value !== null && typeof value === 'object' && value.$slice && value.$each === undefined) {
     value.$each = [];
@@ -2428,7 +2428,7 @@ lastStepModifierFunctions.$push = function (obj, field, value) {
 
   if (value !== null && typeof value === 'object' && value.$each) {
     if (Object.keys(value).length >= 3 || (Object.keys(value).length === 2 && value.$slice === undefined)) { throw new Error("Can only use $slice in cunjunction with $each when $push to array"); }
-    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+    if (!Array.isArray(value.$each)) { throw new Error("$each requires an array value"); }
 
     value.$each.forEach(function (v) {
       obj[field].push(v);
@@ -2466,11 +2466,11 @@ lastStepModifierFunctions.$addToSet = function (obj, field, value) {
   // Create the array if it doesn't exist
   if (!obj.hasOwnProperty(field)) { obj[field] = []; }
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $addToSet an element on non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $addToSet an element on non-array values"); }
 
   if (value !== null && typeof value === 'object' && value.$each) {
     if (Object.keys(value).length > 1) { throw new Error("Can't use another field in conjunction with $each"); }
-    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+    if (!Array.isArray(value.$each)) { throw new Error("$each requires an array value"); }
 
     value.$each.forEach(function (v) {
       lastStepModifierFunctions.$addToSet(obj, field, v);
@@ -2488,7 +2488,7 @@ lastStepModifierFunctions.$addToSet = function (obj, field, value) {
  * Remove the first or last element of an array
  */
 lastStepModifierFunctions.$pop = function (obj, field, value) {
-  if (!util.isArray(obj[field])) { throw new Error("Can't $pop an element from non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $pop an element from non-array values"); }
   if (typeof value !== 'number') { throw new Error(value + " isn't an integer, can't use it with $pop"); }
   if (value === 0) { return; }
 
@@ -2506,7 +2506,7 @@ lastStepModifierFunctions.$pop = function (obj, field, value) {
 lastStepModifierFunctions.$pull = function (obj, field, value) {
   var arr, i;
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $pull an element from non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $pull an element from non-array values"); }
 
   arr = obj[field];
   for (i = arr.length - 1; i >= 0; i -= 1) {
@@ -2648,7 +2648,7 @@ function getDotValue (obj, field) {
 
   if (fieldParts.length === 1) { return obj[fieldParts[0]]; }
 
-  if (util.isArray(obj[fieldParts[0]])) {
+  if (Array.isArray(obj[fieldParts[0]])) {
     // If the next field is an integer, return only this item of the array
     i = parseInt(fieldParts[1], 10);
     if (typeof i === 'number' && !isNaN(i)) {
@@ -2681,11 +2681,11 @@ function areThingsEqual (a, b) {
       b === null || typeof b === 'string' || typeof b === 'boolean' || typeof b === 'number') { return a === b; }
 
   // Dates
-  if (util.isDate(a) || util.isDate(b)) { return util.isDate(a) && util.isDate(b) && a.getTime() === b.getTime(); }
+  if (util.types.isDate(a) || util.types.isDate(b)) { return util.types.isDate(a) && util.types.isDate(b) && a.getTime() === b.getTime(); }
 
   // Arrays (no match since arrays are used as a $in)
   // undefined (no match since they mean field doesn't exist and can't be serialized)
-  if ((!(util.isArray(a) && util.isArray(b)) && (util.isArray(a) || util.isArray(b))) || a === undefined || b === undefined) { return false; }
+  if ((!(Array.isArray(a) && Array.isArray(b)) && (Array.isArray(a) || Array.isArray(b))) || a === undefined || b === undefined) { return false; }
 
   // General objects (check for deep equality)
   // a and b should be objects at this point
@@ -2709,8 +2709,8 @@ function areThingsEqual (a, b) {
  * Check that two values are comparable
  */
 function areComparable (a, b) {
-  if (typeof a !== 'string' && typeof a !== 'number' && !util.isDate(a) &&
-      typeof b !== 'string' && typeof b !== 'number' && !util.isDate(b)) {
+  if (typeof a !== 'string' && typeof a !== 'number' && !util.types.isDate(a) &&
+      typeof b !== 'string' && typeof b !== 'number' && !util.types.isDate(b)) {
     return false;
   }
 
@@ -2749,7 +2749,7 @@ comparisonFunctions.$ne = function (a, b) {
 comparisonFunctions.$in = function (a, b) {
   var i;
 
-  if (!util.isArray(b)) { throw new Error("$in operator called with a non-array"); }
+  if (!Array.isArray(b)) { throw new Error("$in operator called with a non-array"); }
 
   for (i = 0; i < b.length; i += 1) {
     if (areThingsEqual(a, b[i])) { return true; }
@@ -2759,13 +2759,13 @@ comparisonFunctions.$in = function (a, b) {
 };
 
 comparisonFunctions.$nin = function (a, b) {
-  if (!util.isArray(b)) { throw new Error("$nin operator called with a non-array"); }
+  if (!Array.isArray(b)) { throw new Error("$nin operator called with a non-array"); }
 
   return !comparisonFunctions.$in(a, b);
 };
 
 comparisonFunctions.$regex = function (a, b) {
-  if (!util.isRegExp(b)) { throw new Error("$regex operator called with non regular expression"); }
+  if (!(b instanceof RegExp)) { throw new Error("$regex operator called with non regular expression"); }
 
   if (typeof a !== 'string') {
     return false
@@ -2790,13 +2790,13 @@ comparisonFunctions.$exists = function (value, exists) {
 
 // Specific to arrays
 comparisonFunctions.$size = function (obj, value) {
-    if (!util.isArray(obj)) { return false; }
+    if (!Array.isArray(obj)) { return false; }
     if (value % 1 !== 0) { throw new Error("$size operator called without an integer"); }
 
     return (obj.length == value);
 };
 comparisonFunctions.$elemMatch = function (obj, value) {
-  if (!util.isArray(obj)) { return false; }
+  if (!Array.isArray(obj)) { return false; }
   var i = obj.length;
   var result = false;   // Initialize result
   while (i--) {
@@ -2819,7 +2819,7 @@ arrayComparisonFunctions.$elemMatch = true;
 logicalOperators.$or = function (obj, query) {
   var i;
 
-  if (!util.isArray(query)) { throw new Error("$or operator used without an array"); }
+  if (!Array.isArray(query)) { throw new Error("$or operator used without an array"); }
 
   for (i = 0; i < query.length; i += 1) {
     if (match(obj, query[i])) { return true; }
@@ -2837,7 +2837,7 @@ logicalOperators.$or = function (obj, query) {
 logicalOperators.$and = function (obj, query) {
   var i;
 
-  if (!util.isArray(query)) { throw new Error("$and operator used without an array"); }
+  if (!Array.isArray(query)) { throw new Error("$and operator used without an array"); }
 
   for (i = 0; i < query.length; i += 1) {
     if (!match(obj, query[i])) { return false; }
@@ -2916,14 +2916,14 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
     , i, keys, firstChars, dollarFirstChars;
 
   // Check if the value is an array if we don't force a treatment as value
-  if (util.isArray(objValue) && !treatObjAsValue) {
+  if (Array.isArray(objValue) && !treatObjAsValue) {
     // If the queryValue is an array, try to perform an exact match
-    if (util.isArray(queryValue)) {
+    if (Array.isArray(queryValue)) {
       return matchQueryPart(obj, queryKey, queryValue, true);
     }
 
     // Check if we are using an array-specific comparison function
-    if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
+    if (queryValue !== null && typeof queryValue === 'object' && !(queryValue instanceof RegExp)) {
       keys = Object.keys(queryValue);
       for (i = 0; i < keys.length; i += 1) {
         if (arrayComparisonFunctions[keys[i]]) { return matchQueryPart(obj, queryKey, queryValue, true); }
@@ -2939,7 +2939,7 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
 
   // queryValue is an actual object. Determine whether it contains comparison operators
   // or only normal fields. Mixed objects are not allowed
-  if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue) && !util.isArray(queryValue)) {
+  if (queryValue !== null && typeof queryValue === 'object' && !(queryValue instanceof RegExp) && !Array.isArray(queryValue)) {
     keys = Object.keys(queryValue);
     firstChars = _.map(keys, function (item) { return item[0]; });
     dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; });
@@ -2960,7 +2960,7 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
   }
 
   // Using regular expressions with basic querying
-  if (util.isRegExp(queryValue)) { return comparisonFunctions.$regex(objValue, queryValue); }
+  if (queryValue instanceof RegExp) { return comparisonFunctions.$regex(objValue, queryValue); }
 
   // queryValue is either a native value or a normal object
   // Basic matching is possible

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -269,7 +269,7 @@ Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callba
     // For a basic match
     usableQueryKeys = [];
     Object.keys(query).forEach(function (k) {
-      if (typeof query[k] === 'string' || typeof query[k] === 'number' || typeof query[k] === 'boolean' || util.isDate(query[k]) || query[k] === null) {
+      if (typeof query[k] === 'string' || typeof query[k] === 'number' || typeof query[k] === 'boolean' || util.types.isDate(query[k]) || query[k] === null) {
         usableQueryKeys.push(k);
       }
     });
@@ -314,7 +314,7 @@ Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callba
     docs.forEach(function (doc) {
       var valid = true;
       ttlIndexesFieldNames.forEach(function (i) {
-        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
+        if (doc[i] !== undefined && util.types.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
           valid = false;
         }
       });
@@ -351,7 +351,7 @@ Datastore.prototype._insert = function (newDoc, cb) {
     return callback(e);
   }
 
-  this.persistence.persistNewState(util.isArray(preparedDoc) ? preparedDoc : [preparedDoc], function (err) {
+  this.persistence.persistNewState(Array.isArray(preparedDoc) ? preparedDoc : [preparedDoc], function (err) {
     if (err) { return callback(err); }
     return callback(null, model.deepCopy(preparedDoc));
   });
@@ -377,7 +377,7 @@ Datastore.prototype.createNewId = function () {
 Datastore.prototype.prepareDocumentForInsertion = function (newDoc) {
   var preparedDoc, self = this;
 
-  if (util.isArray(newDoc)) {
+  if (Array.isArray(newDoc)) {
     preparedDoc = [];
     newDoc.forEach(function (doc) { preparedDoc.push(self.prepareDocumentForInsertion(doc)); });
   } else {
@@ -397,7 +397,7 @@ Datastore.prototype.prepareDocumentForInsertion = function (newDoc) {
  * @api private
  */
 Datastore.prototype._insertInCache = function (preparedDoc) {
-  if (util.isArray(preparedDoc)) {
+  if (Array.isArray(preparedDoc)) {
     this._insertMultipleDocsInCache(preparedDoc);
   } else {
     this.addToIndexes(preparedDoc);

--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -19,7 +19,7 @@ function projectForUnique (elt) {
   if (typeof elt === 'string') { return '$string' + elt; }
   if (typeof elt === 'boolean') { return '$boolean' + elt; }
   if (typeof elt === 'number') { return '$number' + elt; }
-  if (util.isArray(elt)) { return '$date' + elt.getTime(); }
+  if (Array.isArray(elt)) { return '$date' + elt.getTime(); }
 
   return elt;   // Arrays and objects, will check for pointer equality
 }
@@ -66,14 +66,14 @@ Index.prototype.insert = function (doc) {
     , keys, i, failingI, error
     ;
 
-  if (util.isArray(doc)) { this.insertMultipleDocs(doc); return; }
+  if (Array.isArray(doc)) { this.insertMultipleDocs(doc); return; }
 
   key = model.getDotValue(doc, this.fieldName);
 
   // We don't index documents that don't contain the field if the index is sparse
   if (key === undefined && this.sparse) { return; }
 
-  if (!util.isArray(key)) {
+  if (!Array.isArray(key)) {
     this.tree.insert(key, doc);
   } else {
     // If an insert fails due to a unique constraint, roll back all inserts before it
@@ -138,13 +138,13 @@ Index.prototype.insertMultipleDocs = function (docs) {
 Index.prototype.remove = function (doc) {
   var key, self = this;
 
-  if (util.isArray(doc)) { doc.forEach(function (d) { self.remove(d); }); return; }
+  if (Array.isArray(doc)) { doc.forEach(function (d) { self.remove(d); }); return; }
 
   key = model.getDotValue(doc, this.fieldName);
 
   if (key === undefined && this.sparse) { return; }
 
-  if (!util.isArray(key)) {
+  if (!Array.isArray(key)) {
     this.tree.delete(key, doc);
   } else {
     _.uniq(key, projectForUnique).forEach(function (_key) {
@@ -160,7 +160,7 @@ Index.prototype.remove = function (doc) {
  * Naive implementation, still in O(log(n))
  */
 Index.prototype.update = function (oldDoc, newDoc) {
-  if (util.isArray(oldDoc)) { this.updateMultipleDocs(oldDoc); return; }
+  if (Array.isArray(oldDoc)) { this.updateMultipleDocs(oldDoc); return; }
 
   this.remove(oldDoc);
 
@@ -219,7 +219,7 @@ Index.prototype.updateMultipleDocs = function (pairs) {
 Index.prototype.revertUpdate = function (oldDoc, newDoc) {
   var revert = [];
 
-  if (!util.isArray(oldDoc)) {
+  if (!Array.isArray(oldDoc)) {
     this.update(newDoc, oldDoc);
   } else {
     oldDoc.forEach(function (pair) {
@@ -238,7 +238,7 @@ Index.prototype.revertUpdate = function (oldDoc, newDoc) {
 Index.prototype.getMatching = function (value) {
   var self = this;
 
-  if (!util.isArray(value)) {
+  if (!Array.isArray(value)) {
     return self.tree.search(value);
   } else {
     var _res = {}, res = [];

--- a/lib/model.js
+++ b/lib/model.js
@@ -43,7 +43,7 @@ function checkKey (k, v) {
  * Works by applying the above checkKey function to all fields recursively
  */
 function checkObject (obj) {
-  if (util.isArray(obj)) {
+  if (Array.isArray(obj)) {
     obj.forEach(function (o) {
       checkObject(o);
     });
@@ -113,11 +113,11 @@ function deepCopy (obj, strictKeys) {
        typeof obj === 'number' ||
        typeof obj === 'string' ||
        obj === null ||
-       (util.isDate(obj)) ) {
+       (util.types.isDate(obj)) ) {
     return obj;
   }
 
-  if (util.isArray(obj)) {
+  if (Array.isArray(obj)) {
     res = [];
     obj.forEach(function (o) { res.push(deepCopy(o, strictKeys)); });
     return res;
@@ -146,8 +146,8 @@ function isPrimitiveType (obj) {
        typeof obj === 'number' ||
        typeof obj === 'string' ||
        obj === null ||
-       util.isDate(obj) ||
-       util.isArray(obj));
+       util.types.isDate(obj) ||
+       Array.isArray(obj));
 }
 
 
@@ -211,12 +211,12 @@ function compareThings (a, b, _compareStrings) {
   if (typeof b === 'boolean') { return typeof a === 'boolean' ? compareNSB(a, b) : 1; }
 
   // Dates
-  if (util.isDate(a)) { return util.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1; }
-  if (util.isDate(b)) { return util.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1; }
+  if (util.types.isDate(a)) { return util.types.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1; }
+  if (util.types.isDate(b)) { return util.types.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1; }
 
   // Arrays (first element is most significant and so on)
-  if (util.isArray(a)) { return util.isArray(b) ? compareArrays(a, b) : -1; }
-  if (util.isArray(b)) { return util.isArray(a) ? compareArrays(a, b) : 1; }
+  if (Array.isArray(a)) { return Array.isArray(b) ? compareArrays(a, b) : -1; }
+  if (Array.isArray(b)) { return Array.isArray(a) ? compareArrays(a, b) : 1; }
 
   // Objects
   aKeys = Object.keys(a).sort();
@@ -272,7 +272,7 @@ lastStepModifierFunctions.$push = function (obj, field, value) {
   // Create the array if it doesn't exist
   if (!obj.hasOwnProperty(field)) { obj[field] = []; }
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $push an element on non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $push an element on non-array values"); }
 
   if (value !== null && typeof value === 'object' && value.$slice && value.$each === undefined) {
     value.$each = [];
@@ -280,7 +280,7 @@ lastStepModifierFunctions.$push = function (obj, field, value) {
 
   if (value !== null && typeof value === 'object' && value.$each) {
     if (Object.keys(value).length >= 3 || (Object.keys(value).length === 2 && value.$slice === undefined)) { throw new Error("Can only use $slice in cunjunction with $each when $push to array"); }
-    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+    if (!Array.isArray(value.$each)) { throw new Error("$each requires an array value"); }
 
     value.$each.forEach(function (v) {
       obj[field].push(v);
@@ -318,11 +318,11 @@ lastStepModifierFunctions.$addToSet = function (obj, field, value) {
   // Create the array if it doesn't exist
   if (!obj.hasOwnProperty(field)) { obj[field] = []; }
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $addToSet an element on non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $addToSet an element on non-array values"); }
 
   if (value !== null && typeof value === 'object' && value.$each) {
     if (Object.keys(value).length > 1) { throw new Error("Can't use another field in conjunction with $each"); }
-    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+    if (!Array.isArray(value.$each)) { throw new Error("$each requires an array value"); }
 
     value.$each.forEach(function (v) {
       lastStepModifierFunctions.$addToSet(obj, field, v);
@@ -340,7 +340,7 @@ lastStepModifierFunctions.$addToSet = function (obj, field, value) {
  * Remove the first or last element of an array
  */
 lastStepModifierFunctions.$pop = function (obj, field, value) {
-  if (!util.isArray(obj[field])) { throw new Error("Can't $pop an element from non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $pop an element from non-array values"); }
   if (typeof value !== 'number') { throw new Error(value + " isn't an integer, can't use it with $pop"); }
   if (value === 0) { return; }
 
@@ -358,7 +358,7 @@ lastStepModifierFunctions.$pop = function (obj, field, value) {
 lastStepModifierFunctions.$pull = function (obj, field, value) {
   var arr, i;
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $pull an element from non-array values"); }
+  if (!Array.isArray(obj[field])) { throw new Error("Can't $pull an element from non-array values"); }
 
   arr = obj[field];
   for (i = arr.length - 1; i >= 0; i -= 1) {
@@ -500,7 +500,7 @@ function getDotValue (obj, field) {
 
   if (fieldParts.length === 1) { return obj[fieldParts[0]]; }
 
-  if (util.isArray(obj[fieldParts[0]])) {
+  if (Array.isArray(obj[fieldParts[0]])) {
     // If the next field is an integer, return only this item of the array
     i = parseInt(fieldParts[1], 10);
     if (typeof i === 'number' && !isNaN(i)) {
@@ -533,11 +533,11 @@ function areThingsEqual (a, b) {
       b === null || typeof b === 'string' || typeof b === 'boolean' || typeof b === 'number') { return a === b; }
 
   // Dates
-  if (util.isDate(a) || util.isDate(b)) { return util.isDate(a) && util.isDate(b) && a.getTime() === b.getTime(); }
+  if (util.types.isDate(a) || util.types.isDate(b)) { return util.types.isDate(a) && util.types.isDate(b) && a.getTime() === b.getTime(); }
 
   // Arrays (no match since arrays are used as a $in)
   // undefined (no match since they mean field doesn't exist and can't be serialized)
-  if ((!(util.isArray(a) && util.isArray(b)) && (util.isArray(a) || util.isArray(b))) || a === undefined || b === undefined) { return false; }
+  if ((!(Array.isArray(a) && Array.isArray(b)) && (Array.isArray(a) || Array.isArray(b))) || a === undefined || b === undefined) { return false; }
 
   // General objects (check for deep equality)
   // a and b should be objects at this point
@@ -561,8 +561,8 @@ function areThingsEqual (a, b) {
  * Check that two values are comparable
  */
 function areComparable (a, b) {
-  if (typeof a !== 'string' && typeof a !== 'number' && !util.isDate(a) &&
-      typeof b !== 'string' && typeof b !== 'number' && !util.isDate(b)) {
+  if (typeof a !== 'string' && typeof a !== 'number' && !util.types.isDate(a) &&
+      typeof b !== 'string' && typeof b !== 'number' && !util.types.isDate(b)) {
     return false;
   }
 
@@ -601,7 +601,7 @@ comparisonFunctions.$ne = function (a, b) {
 comparisonFunctions.$in = function (a, b) {
   var i;
 
-  if (!util.isArray(b)) { throw new Error("$in operator called with a non-array"); }
+  if (!Array.isArray(b)) { throw new Error("$in operator called with a non-array"); }
 
   for (i = 0; i < b.length; i += 1) {
     if (areThingsEqual(a, b[i])) { return true; }
@@ -611,13 +611,13 @@ comparisonFunctions.$in = function (a, b) {
 };
 
 comparisonFunctions.$nin = function (a, b) {
-  if (!util.isArray(b)) { throw new Error("$nin operator called with a non-array"); }
+  if (!Array.isArray(b)) { throw new Error("$nin operator called with a non-array"); }
 
   return !comparisonFunctions.$in(a, b);
 };
 
 comparisonFunctions.$regex = function (a, b) {
-  if (!util.isRegExp(b)) { throw new Error("$regex operator called with non regular expression"); }
+  if (!(b instanceof RegExp)) { throw new Error("$regex operator called with non regular expression"); }
 
   if (typeof a !== 'string') {
     return false
@@ -642,13 +642,13 @@ comparisonFunctions.$exists = function (value, exists) {
 
 // Specific to arrays
 comparisonFunctions.$size = function (obj, value) {
-    if (!util.isArray(obj)) { return false; }
+    if (!Array.isArray(obj)) { return false; }
     if (value % 1 !== 0) { throw new Error("$size operator called without an integer"); }
 
     return (obj.length == value);
 };
 comparisonFunctions.$elemMatch = function (obj, value) {
-  if (!util.isArray(obj)) { return false; }
+  if (!Array.isArray(obj)) { return false; }
   var i = obj.length;
   var result = false;   // Initialize result
   while (i--) {
@@ -671,7 +671,7 @@ arrayComparisonFunctions.$elemMatch = true;
 logicalOperators.$or = function (obj, query) {
   var i;
 
-  if (!util.isArray(query)) { throw new Error("$or operator used without an array"); }
+  if (!Array.isArray(query)) { throw new Error("$or operator used without an array"); }
 
   for (i = 0; i < query.length; i += 1) {
     if (match(obj, query[i])) { return true; }
@@ -689,7 +689,7 @@ logicalOperators.$or = function (obj, query) {
 logicalOperators.$and = function (obj, query) {
   var i;
 
-  if (!util.isArray(query)) { throw new Error("$and operator used without an array"); }
+  if (!Array.isArray(query)) { throw new Error("$and operator used without an array"); }
 
   for (i = 0; i < query.length; i += 1) {
     if (!match(obj, query[i])) { return false; }
@@ -768,14 +768,14 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
     , i, keys, firstChars, dollarFirstChars;
 
   // Check if the value is an array if we don't force a treatment as value
-  if (util.isArray(objValue) && !treatObjAsValue) {
+  if (Array.isArray(objValue) && !treatObjAsValue) {
     // If the queryValue is an array, try to perform an exact match
-    if (util.isArray(queryValue)) {
+    if (Array.isArray(queryValue)) {
       return matchQueryPart(obj, queryKey, queryValue, true);
     }
 
     // Check if we are using an array-specific comparison function
-    if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
+    if (queryValue !== null && typeof queryValue === 'object' && !(queryValue instanceof RegExp)) {
       keys = Object.keys(queryValue);
       for (i = 0; i < keys.length; i += 1) {
         if (arrayComparisonFunctions[keys[i]]) { return matchQueryPart(obj, queryKey, queryValue, true); }
@@ -791,7 +791,7 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
 
   // queryValue is an actual object. Determine whether it contains comparison operators
   // or only normal fields. Mixed objects are not allowed
-  if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue) && !util.isArray(queryValue)) {
+  if (queryValue !== null && typeof queryValue === 'object' && !(queryValue instanceof RegExp) && !Array.isArray(queryValue)) {
     keys = Object.keys(queryValue);
     firstChars = _.map(keys, function (item) { return item[0]; });
     dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; });
@@ -812,7 +812,7 @@ function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
   }
 
   // Using regular expressions with basic querying
-  if (util.isRegExp(queryValue)) { return comparisonFunctions.$regex(objValue, queryValue); }
+  if (queryValue instanceof RegExp) { return comparisonFunctions.$regex(objValue, queryValue); }
 
   // queryValue is either a native value or a normal object
   // Basic matching is possible

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -84,7 +84,7 @@ describe('Model', function () {
       c = model.deserialize(b);
       b.indexOf('\n').should.equal(-1);
       b.should.equal('{"test":{"$$date":' + d.getTime() + '}}');
-      util.isDate(c.test).should.equal(true);
+      util.types.isDate(c.test).should.equal(true);
       c.test.getTime().should.equal(d.getTime());
     });
 


### PR DESCRIPTION
Changes: 

- Replaced deprecated methods to support Node v24:
   - `util.isDate()` » `util.types.isDate()`
   - `util.isRegExp()`» `instanceof RegExp`
   - `util.isArray()` » `Array.isArray()`