### PR TITLE
Upgrade underscore and @sailshq/binary-search-tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "async": "0.2.10",
-    "@sailshq/binary-search-tree": "0.2.7",
+    "@sailshq/binary-search-tree": "^0.2.8",
     "localforage": "1.3.0",
     "mkdirp": "0.5.6",
-    "underscore": "1.13.1"
+    "underscore": "1.13.8"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
Changes:
- bumped @sailshq/binary-search-tree `0.2.7` » `^0.2.8`
- bumped underscore `1.13.1` » `1.13.8`